### PR TITLE
Remove large header from hero & update description

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,6 +1,6 @@
 # basic info
 title = 'aditya'
-baseURL = 'https://adityarathod.github.io'
+baseURL = 'https://adibytes.dev'
 languageCode = 'en-us'
 theme = 'adi'
 googleAnalytics = 'G-N0PPYCM4QZ'
@@ -17,10 +17,10 @@ description = 'Software engineer that loves building cool stuff with data and co
 
 # hero params
 [params.hero]
-bigTitle = "👋 hi, i'm aditya."
 description = [
-    "I'm a software engineer with a focus on distributed systems and networks.",
-    "In my free time, I learn guitar, cook, listen to [lots of music](https://www.last.fm/user/adibytes), and [feed the enemy team in League](https://na.op.gg/summoners/na/Dichotomous)."
+    "Hi! I'm a software engineer with a focus on distributed systems and networks.",
+    "I currently work on network-layer DDoS protection at AWS.",
+    "In my free time, I learn cook, travel, listen to [lots of music](https://www.last.fm/user/adibytes), and [feed the enemy team in League](https://www.op.gg/summoners/na/Dichotomous-NA1)."
 ]
 
 [params.footer]

--- a/themes/adi/layouts/partials/hero.html
+++ b/themes/adi/layouts/partials/hero.html
@@ -1,9 +1,6 @@
 <section
   class="max-w-a[715px] my-6 text-lg leading-loose md:my-10 md:mr-20 md:text-xl"
 >
-  <h1 class="mb-5 text-3xl font-semibold leading-[1.5] md:text-4xl">
-    {{ site.Params.Hero.BigTitle | default (print `hello there.`) }}
-  </h1>
   {{ $subtitle := site.Params.Hero.Description | default (slice `this is my cool website.`) }}
   <h2 class="my-1 leading-relaxed text-zinc-800 dark:text-zinc-100">
     {{ range $subtitle }}


### PR DESCRIPTION
The large header was getting a bit cringe and I was getting flack for it from my friends (mainly good-natured ribbing, but I felt like it was too ostentatious). So I removed it.

Also updated op.gg link and changed the featured hobbies a bit :)